### PR TITLE
boot: add minimal kernel workspace banner slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["kernel"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+version = "0.1.0"
+authors = ["tosm-os contributors"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 ## Current boot slice
 
-The repository currently targets the first milestone: a minimal x86_64 UEFI boot stub that writes a deterministic banner to COM1 under QEMU and then powers off.
+The repository is progressing through the first milestone (`bootloader and entry`).
+
+This slice introduces a minimal Rust workspace with a host-testable `kernel` crate that owns
+an explicit, deterministic boot banner literal:
+
+- `tosm-os: kernel entry reached`
+
+The UEFI entry crate and QEMU smoke wiring remain the next incremental steps.
 
 ## Codex + CI workflow
 
@@ -9,13 +16,6 @@ The repository currently targets the first milestone: a minimal x86_64 UEFI boot
 - The `CI` workflow uploads logs and reports as artifacts.
 - The `Project status` workflow copies the latest CI outcome, report summaries, and log excerpts into `docs/status/` on `main`.
 - On the next Codex run, it should read `docs/status/current.md`, `docs/status/ci-feedback.json`, `docs/status/latest-ci.md`, and the generated reports/log excerpts before deciding whether to continue the milestone or fix a prior failure.
-
-## Prerequisites
-
-- Rust stable with `rustfmt` and `clippy`
-- Rust target `x86_64-unknown-uefi`
-- `qemu-system-x86_64`
-- OVMF firmware available in a standard QEMU installation path
 
 ## Verification commands
 
@@ -26,9 +26,3 @@ These are the commands GitHub Actions is expected to run after merge:
 - `make test`
 - `make build`
 - `make smoke`
-
-## Notes
-
-- `make build` builds the host-testable `kernel` crate and the UEFI boot artifact.
-- `make smoke` stages `BOOTX64.EFI`, boots QEMU with OVMF, and asserts the serial banner `tosm-os: kernel entry reached`.
-- `make qemu` and `make smoke` auto-select PowerShell scripts when available, and use POSIX shell scripts otherwise.

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -4,45 +4,45 @@ Create the smallest bootable x86_64 Rust OS slice that can start in QEMU and emi
 
 ## Current state
 
-- Repository contains a Cargo workspace with `kernel` and `boot/uefi` crates.
+- Repository now contains a Cargo workspace with a minimal `kernel` crate.
+- The `kernel` crate exports a deterministic boot banner literal and byte-slice helper for future firmware serial output wiring.
 - Active milestone is `bootloader and entry`.
-- Active subtask is `kernel entry stub boots in QEMU and writes to serial`.
 
 ## Constraints
 
-- Keep the change buildable and testable.
+- Keep each change buildable and reviewable.
 - Stay on the active milestone only.
 - Prefer the smallest correct slice over broader subsystem work.
 - Update docs when behavior changes.
-- Verification must run through `make fmt`, `make lint`, `make test`, `make build`, and `make smoke`.
+- Verification is delegated to GitHub Actions after merge.
 
 ## Design choice
 
-Use a minimal Cargo workspace with:
+Build the milestone incrementally:
 
-- a host-testable `kernel` crate that owns the deterministic banner literal
-- a `boot/uefi` no_std firmware entry that performs serial output and shutdown via raw UEFI ABI structures
-- no external crates in the boot path to keep offline builds and auditing simpler
-- dual smoke/QEMU scripts (PowerShell and POSIX shell) selected by `make`
+- start with a tiny no_std `kernel` crate that defines the canonical boot banner
+- add a separate UEFI entry crate next that consumes this banner and writes to COM1
+- only then add QEMU smoke automation tied to the expected serial output
 
-This keeps the first milestone narrow while leaving a clean path for later interrupt and memory work.
+This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
 ## Implementation steps
 
-1. Keep the workspace and kernel crate minimal and deterministic.
-2. Implement the UEFI entry stub, panic handler, and COM1 serial writer.
-3. Add QEMU runner and smoke-test scripts for both PowerShell and POSIX shells.
-4. Wire scripts into the existing `Makefile` with automatic host-shell selection.
-5. Update README and status docs for the current workflow and blockers.
-6. Run required verification and fix the smallest root cause if anything fails.
+1. ✅ Create Cargo workspace and minimal host-testable `kernel` crate.
+2. ⏳ Implement UEFI entry stub, panic handler, and COM1 serial writer.
+3. ⏳ Add QEMU runner and smoke-test scripts.
+4. ⏳ Wire scripts into `make` targets.
+5. ⏳ Update README and status docs for each slice.
 
 ## Risks
 
-- Missing `x86_64-unknown-uefi` target blocks UEFI build/lint/smoke steps.
-- Missing QEMU or OVMF firmware blocks runtime smoke tests.
-- Manual UEFI ABI definitions are sensitive to layout mistakes and require strict `repr(C)` correctness.
+- Missing `x86_64-unknown-uefi` target can block UEFI build/lint/smoke steps later.
+- Missing QEMU/OVMF can block runtime smoke checks later.
+- Hand-written ABI structs in the UEFI slice need careful layout validation.
 
 ## Verification steps
+
+Expected GitHub Actions verification after merge:
 
 - `make fmt`
 - `make lint`

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,9 +1,9 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: kernel entry stub boots in QEMU and writes to serial
-- Status: awaiting_ci_feedback
-- Note: Codex should write code/docs only, then rely on GitHub Actions after merge to `main`. Read the latest CI automation section below before starting the next slice.
+- Subtask: kernel crate defines deterministic boot banner for upcoming UEFI entry wiring
+- Status: ready_for_ci
+- Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria
 - [ ] cargo fmt --all

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kernel"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = []

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![forbid(unsafe_op_in_unsafe_fn)]
+
+/// Deterministic serial banner used by the boot milestone smoke test.
+pub const BOOT_BANNER: &str = "tosm-os: kernel entry reached";
+
+/// Returns the kernel boot banner as a byte slice for firmware serial writers.
+#[must_use]
+pub const fn boot_banner_bytes() -> &'static [u8] {
+    BOOT_BANNER.as_bytes()
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::{boot_banner_bytes, BOOT_BANNER};
+
+    #[test]
+    fn boot_banner_matches_expected_literal() {
+        assert_eq!(BOOT_BANNER, "tosm-os: kernel entry reached");
+    }
+
+    #[test]
+    fn boot_banner_bytes_are_stable() {
+        assert_eq!(boot_banner_bytes(), b"tosm-os: kernel entry reached");
+    }
+}


### PR DESCRIPTION
### Motivation

- Define a single canonical boot banner for the active `bootloader and entry` milestone so subsequent UEFI entry wiring and smoke tests reference one deterministic literal.
- The repository currently has no post-merge CI evidence, so the smallest safe next change is a focused host-testable `kernel` slice rather than adding firmware/Uefi ABI code now.

### Description

- Add a root Cargo workspace (`Cargo.toml`) and a minimal `kernel` crate (`kernel/Cargo.toml` and `kernel/src/lib.rs`) that exports `BOOT_BANNER` and a `const fn boot_banner_bytes()` helper.
- Add focused unit tests in `kernel/src/lib.rs` that lock the expected banner literal and byte content for future smoke tests.
- Update planning and status documents (`docs/plan/boot-entry.md`, `docs/status/current.md`) and `README.md` to reflect the new slice and next steps.

### Testing

- No automated CI runs have been performed yet; GitHub Actions is expected to run `make fmt`, `make lint`, `make test`, `make build`, and `make smoke` after this is merged.
- Unit tests were added to the `kernel` crate but were not executed locally and will be validated by the CI `make test` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cd1a8850832f89f9d5e5be0c0206)