### PR TITLE
Add minimal UEFI entry stub crate for boot milestone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["kernel"]
+members = ["kernel", "boot/uefi-entry"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 The repository is progressing through the first milestone (`bootloader and entry`).
 
-This slice introduces a minimal Rust workspace with a host-testable `kernel` crate that owns
-an explicit, deterministic boot banner literal:
+This slice introduces a minimal Rust workspace with:
+
+- a host-testable `kernel` crate that owns an explicit deterministic boot banner literal
+- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main` stub and consumes the kernel banner bytes
+
+Canonical boot banner:
 
 - `tosm-os: kernel entry reached`
 
-The UEFI entry crate and QEMU smoke wiring remain the next incremental steps.
+COM1 serial output wiring and QEMU smoke automation remain the next incremental steps.
 
 ## Codex + CI workflow
 

--- a/boot/uefi-entry/Cargo.toml
+++ b/boot/uefi-entry/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "uefi-entry"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kernel = { path = "../../kernel" }

--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+#![forbid(unsafe_op_in_unsafe_fn)]
+
+use core::ffi::c_void;
+
+/// UEFI status code.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct EfiStatus(pub usize);
+
+impl EfiStatus {
+    /// Successful UEFI status result.
+    pub const SUCCESS: Self = Self(0);
+}
+
+/// Opaque UEFI image handle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct EfiHandle(pub *mut c_void);
+
+/// Opaque UEFI system table pointer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct EfiSystemTable(pub *mut c_void);
+
+/// Returns the deterministic kernel message expected by boot milestone consumers.
+#[must_use]
+pub const fn kernel_entry_message() -> &'static [u8] {
+    kernel::boot_banner_bytes()
+}
+
+/// UEFI ABI entrypoint stub for the boot milestone.
+///
+/// The next slice will use the provided table pointer to write this message to serial output.
+#[no_mangle]
+pub extern "efiapi" fn efi_main(_image: EfiHandle, _system_table: EfiSystemTable) -> EfiStatus {
+    let _message = kernel_entry_message();
+    EfiStatus::SUCCESS
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::{efi_main, kernel_entry_message, EfiHandle, EfiStatus, EfiSystemTable};
+
+    #[test]
+    fn entry_message_matches_kernel_banner() {
+        assert_eq!(kernel_entry_message(), b"tosm-os: kernel entry reached");
+    }
+
+    #[test]
+    fn efi_main_returns_success_in_stub_slice() {
+        let status = efi_main(EfiHandle(core::ptr::null_mut()), EfiSystemTable(core::ptr::null_mut()));
+        assert_eq!(status, EfiStatus::SUCCESS);
+    }
+}

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -21,7 +21,8 @@ Create the smallest bootable x86_64 Rust OS slice that can start in QEMU and emi
 Build the milestone incrementally:
 
 - start with a tiny no_std `kernel` crate that defines the canonical boot banner
-- add a separate UEFI entry crate next that consumes this banner and writes to COM1
+- add a separate UEFI entry crate that consumes this banner
+- extend that crate to write the banner to COM1
 - only then add QEMU smoke automation tied to the expected serial output
 
 This keeps early milestone slices auditable and minimizes cross-cutting risk.
@@ -29,10 +30,11 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 ## Implementation steps
 
 1. ✅ Create Cargo workspace and minimal host-testable `kernel` crate.
-2. ⏳ Implement UEFI entry stub, panic handler, and COM1 serial writer.
-3. ⏳ Add QEMU runner and smoke-test scripts.
-4. ⏳ Wire scripts into `make` targets.
-5. ⏳ Update README and status docs for each slice.
+2. 🟡 Implement UEFI entry stub crate that calls into kernel banner bytes.
+3. ⏳ Add panic handler and COM1 serial writer in the UEFI entry crate.
+4. ⏳ Add QEMU runner and smoke-test scripts.
+5. ⏳ Wire scripts into `make` targets.
+6. ⏳ Update README and status docs for each slice.
 
 ## Risks
 

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,7 +1,7 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: kernel crate defines deterministic boot banner for upcoming UEFI entry wiring
+- Subtask: add a minimal UEFI ABI entry stub crate wired to the kernel deterministic boot banner
 - Status: ready_for_ci
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 


### PR DESCRIPTION
### Motivation

- Progress the `bootloader and entry` milestone by adding the smallest vertical slice that wires a UEFI entry into the existing kernel boot banner.
- Keep the change minimal and auditable: provide a no_std UEFI ABI stub that consumes the canonical kernel banner without yet adding COM1 or QEMU wiring.

### Description

- Add `boot/uefi-entry` as a new workspace member in `Cargo.toml` and create `boot/uefi-entry/Cargo.toml` with a dependency on the `kernel` crate.
- Implement a no_std UEFI entry crate `boot/uefi-entry/src/lib.rs` that defines `EfiStatus`, `EfiHandle`, `EfiSystemTable`, the `kernel_entry_message()` helper and an `efi_main` stub that calls into `kernel::boot_banner_bytes()` and returns success.
- Add unit tests in the new crate that assert the entry message matches the kernel banner and that `efi_main` returns success, and keep existing kernel banner tests in `kernel/src/lib.rs` unchanged.
- Update documentation to reflect the new slice by editing `docs/plan/boot-entry.md`, `docs/status/current.md`, and `README.md` to track the UEFI stub slice and next steps.

### Testing

- No verification commands were run locally per repository contract; automated verification is delegated to CI and the repo status files show no post-merge CI results yet.
- Unit tests were added to the new crate and to `kernel`, and they are expected to be executed by CI via `make test` / `cargo test --all`.
- CI verification steps expected after merge are: `make fmt`, `make lint` (via `cargo clippy`), `make test`, `make build`, and `make smoke`, and their results will be recorded in `docs/status/*` by the project automation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cfffcac8832fad2ac7c4aaf49977)