### PR TITLE
Fix smoke test portability regression in CI

### DIFF
--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -32,7 +32,7 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 1. ✅ Create Cargo workspace and minimal host-testable `kernel` crate.
 2. 🟡 Implement UEFI entry stub crate that calls into kernel banner bytes.
 3. ⏳ Add panic handler and COM1 serial writer in the UEFI entry crate.
-4. 🟡 Add initial smoke-test script for banner contract; extend to QEMU runner in a later slice.
+4. ✅ Add initial smoke-test script for banner contract; keep it CI-portable with POSIX tooling and extend to QEMU runner in a later slice.
 5. ⏳ Wire scripts into `make` targets.
 6. ⏳ Update README and status docs for each slice.
 

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,7 +1,7 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: fix CI regressions by formatting UEFI tests and adding the initial smoke-test script
+- Subtask: fix smoke CI regression by making the banner smoke check portable (remove rg dependency)
 - Status: ready_for_ci
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # until the QEMU boot path is added in a later slice.
 expected_banner='tosm-os: kernel entry reached'
 
-if ! rg --fixed-strings --quiet "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
   echo "smoke: expected boot banner not found"
   exit 1
 fi


### PR DESCRIPTION
### Motivation
- Fix the CI `smoke` job failure caused by the smoke script depending on `rg` (ripgrep) which is not available on the runner by making the banner check POSIX-portable.

### Description
- Replace `rg --fixed-strings --quiet` with `grep --fixed-strings --quiet --` in `tools/smoke-test.sh`, and update `docs/status/current.md` and `docs/plan/boot-entry.md` to reflect the portability fix and mark the initial smoke-script step complete.

### Testing
- No local automated tests were run; stored CI reports under `docs/status/` show `format`, `clippy`, `tests`, and `build` previously succeeded while `smoke` failed, and this change targets that `smoke` failure so GitHub Actions will validate on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d412ee3c832f81f36abc431cdc52)