### PR TITLE
Fix uefi-entry clippy dead-code error in COM1 status constants

### DIFF
--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -4,7 +4,6 @@
 use core::ffi::c_void;
 
 const COM1_PORT: u16 = 0x3F8;
-const LINE_STATUS_DATA_READY: u8 = 1;
 const LINE_STATUS_TRANSMITTER_EMPTY: u8 = 1 << 5;
 
 /// UEFI status code.
@@ -123,7 +122,7 @@ extern crate std;
 
 #[cfg(test)]
 mod tests {
-    use super::{kernel_entry_message, EfiStatus, LINE_STATUS_DATA_READY};
+    use super::{kernel_entry_message, EfiStatus, LINE_STATUS_TRANSMITTER_EMPTY};
 
     #[test]
     fn entry_message_matches_kernel_banner() {
@@ -136,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn line_status_data_ready_bit_is_low_bit() {
-        assert_eq!(LINE_STATUS_DATA_READY, 1);
+    fn line_status_transmitter_empty_bit_matches_uart_lsr_spec() {
+        assert_eq!(LINE_STATUS_TRANSMITTER_EMPTY, 1 << 5);
     }
 }

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: add a minimal COM1 serial writer in the UEFI entry path so firmware can emit the kernel banner
-- Status: ready_for_ci
+- Subtask: remove the unused COM1 line-status constant that fails clippy with `-D warnings`
+- Status: ready_for_ci (awaiting CI rerun on this fix)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria


### PR DESCRIPTION
### Motivation
- The latest CI run (`22974365862`) reported a `clippy` failure caused by an unused COM1 line-status constant in the UEFI entry crate, blocking the boot milestone progress. 
- Per the repository contract, the smallest concrete CI failure must be fixed before adding new scope. 

### Description
- Removed the unused `LINE_STATUS_DATA_READY` constant from `boot/uefi-entry/src/lib.rs` to eliminate the `dead_code`/`-D warnings` clippy error. 
- Kept and used the relevant UART bit constant `LINE_STATUS_TRANSMITTER_EMPTY` and updated the unit test to assert that transmitter-empty bit (`1 << 5`) instead of the removed constant. 
- Updated `docs/status/current.md` to record this CI-driven fix slice and mark it as awaiting a CI rerun. 
- Changes are committed with the message: `Fix clippy dead-code failure in uefi-entry`.

### Testing
- The stored CI run `22974365862` (pre-fix) shows `format: success`, `clippy: failure`, `tests: success`, `build: success`, and `smoke: success`, with the `clippy` failure due to `LINE_STATUS_DATA_READY` being unused. 
- No CI run has been executed for this patch yet; the change specifically targets the previously-failing `clippy` check and requires CI to be rerun to verify the fix under the repository's automated checks. 
- Existing unit tests from the prior CI run exercised `uefi-entry` and `kernel` crates and passed on the previous commit according to stored logs; CI must confirm they still pass after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d9307af8832f9552a3996b631a0b)