### PR TITLE
boot: centralize canonical serial banner line in kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The repository is progressing through the first milestone (`bootloader and entry
 
 This slice introduces a minimal Rust workspace with:
 
-- a host-testable `kernel` crate that owns an explicit deterministic boot banner literal
-- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes the kernel banner to COM1, and includes a minimal panic handler
+- a host-testable `kernel` crate that owns an explicit deterministic boot banner literal plus a canonical CRLF-terminated serial line helper
+- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes the kernel-provided banner line to COM1, and includes a minimal panic handler
 
 Canonical boot banner:
 

--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -89,10 +89,10 @@ fn port_read_u8(_port: u16) -> u8 {
     0
 }
 
-/// Returns the deterministic kernel message expected by boot milestone consumers.
+/// Returns the deterministic kernel banner line expected by boot milestone consumers.
 #[must_use]
-pub const fn kernel_entry_message() -> &'static [u8] {
-    kernel::boot_banner_bytes()
+pub const fn kernel_entry_message_line() -> &'static [u8] {
+    kernel::boot_banner_line_bytes()
 }
 
 /// UEFI ABI entrypoint for the boot milestone.
@@ -101,8 +101,7 @@ pub const fn kernel_entry_message() -> &'static [u8] {
 #[no_mangle]
 pub extern "efiapi" fn efi_main(_image: EfiHandle, _system_table: EfiSystemTable) -> EfiStatus {
     let mut serial = SerialCom1::new();
-    serial.write_all(kernel_entry_message());
-    serial.write_all(b"\r\n");
+    serial.write_all(kernel_entry_message_line());
     EfiStatus::SUCCESS
 }
 
@@ -122,11 +121,11 @@ extern crate std;
 
 #[cfg(test)]
 mod tests {
-    use super::{kernel_entry_message, EfiStatus, LINE_STATUS_TRANSMITTER_EMPTY};
+    use super::{kernel_entry_message_line, EfiStatus, LINE_STATUS_TRANSMITTER_EMPTY};
 
     #[test]
-    fn entry_message_matches_kernel_banner() {
-        assert_eq!(kernel_entry_message(), b"tosm-os: kernel entry reached");
+    fn entry_message_line_matches_kernel_banner_with_crlf() {
+        assert_eq!(kernel_entry_message_line(), b"tosm-os: kernel entry reached\r\n");
     }
 
     #[test]

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -24,6 +24,7 @@ Build the milestone incrementally:
 - add a separate UEFI entry crate that consumes this banner
 - extend that crate to write the banner to COM1
 - only then add QEMU smoke automation tied to the expected serial output
+- centralize the canonical CRLF-terminated banner line in the kernel crate so firmware entry paths cannot drift
 
 This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
@@ -35,6 +36,7 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 4. ✅ Add initial smoke-test script for banner contract; keep it CI-portable with POSIX tooling and extend to QEMU runner in a later slice.
 5. ✅ Wire scripts into `make` targets.
 6. ✅ Update README and status docs for each slice.
+7. ✅ Centralize the CRLF-terminated banner line in `kernel` and consume it from `boot/uefi-entry`.
 
 ## Risks
 

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: wire workspace checks and smoke script into canonical `make` targets
-- Status: ready_for_ci (awaiting CI run on make-target wiring)
+- Subtask: centralize canonical boot banner line (with CRLF) in kernel for UEFI serial output reuse
+- Status: ready_for_ci (awaiting CI run on canonical banner-line centralization)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -4,10 +4,19 @@
 /// Deterministic serial banner used by the boot milestone smoke test.
 pub const BOOT_BANNER: &str = "tosm-os: kernel entry reached";
 
+/// Canonical serial line emitted from boot entry paths.
+pub const BOOT_BANNER_LINE: &str = "tosm-os: kernel entry reached\r\n";
+
 /// Returns the kernel boot banner as a byte slice for firmware serial writers.
 #[must_use]
 pub const fn boot_banner_bytes() -> &'static [u8] {
     BOOT_BANNER.as_bytes()
+}
+
+/// Returns the canonical banner line (including CRLF) for serial transmitters.
+#[must_use]
+pub const fn boot_banner_line_bytes() -> &'static [u8] {
+    BOOT_BANNER_LINE.as_bytes()
 }
 
 #[cfg(test)]
@@ -15,7 +24,7 @@ extern crate std;
 
 #[cfg(test)]
 mod tests {
-    use super::{boot_banner_bytes, BOOT_BANNER};
+    use super::{boot_banner_bytes, boot_banner_line_bytes, BOOT_BANNER, BOOT_BANNER_LINE};
 
     #[test]
     fn boot_banner_matches_expected_literal() {
@@ -25,5 +34,11 @@ mod tests {
     #[test]
     fn boot_banner_bytes_are_stable() {
         assert_eq!(boot_banner_bytes(), b"tosm-os: kernel entry reached");
+    }
+
+    #[test]
+    fn boot_banner_line_bytes_include_crlf() {
+        assert_eq!(BOOT_BANNER_LINE, "tosm-os: kernel entry reached\r\n");
+        assert_eq!(boot_banner_line_bytes(), b"tosm-os: kernel entry reached\r\n");
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent drift between kernel and firmware entry output by centralizing the canonical CRLF-terminated boot banner line in the `kernel` crate.
- Keep firmware consumers (UEFI entry) using a single source of truth for serial line formatting to simplify smoke tests and future QEMU automation.

### Description
- Add `BOOT_BANNER_LINE` and `boot_banner_line_bytes()` to `kernel/src/lib.rs` to provide a CRLF-terminated canonical serial line for transmitters. 
- Update `boot/uefi-entry` to consume the canonical line via a new `kernel_entry_message_line()` wrapper and write it directly with `serial.write_all(...)`, removing local newline composition. 
- Add unit test coverage for the new banner line in `kernel` and update `boot/uefi-entry` tests to assert the CRLF-terminated message. 
- Update documentation and planning artifacts (`docs/status/current.md`, `docs/plan/boot-entry.md`, and `README.md`) to reflect the new subtask and implementation step.

### Testing
- Added unit tests: `kernel::boot_banner_line_bytes_include_crlf` and `uefi-entry::entry_message_line_matches_kernel_banner_with_crlf`, which are part of the repository test suite and will be executed by CI under `make test`.
- No CI run has been performed for this new commit yet; per project contract verification is delegated to GitHub Actions and the canonical CI steps are `make fmt`, `make lint`, `make test`, `make build`, and `make smoke`.
- The previously stored CI run referenced in `docs/status` reported success for format, clippy, tests, build, and smoke, but that run predates these changes and does not validate this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dd506428832fa9006ea42990f387)