### PR TITLE
Fix CI formatting failure in boot banner assertion tests

### DIFF
--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -125,7 +125,10 @@ mod tests {
 
     #[test]
     fn entry_message_line_matches_kernel_banner_with_crlf() {
-        assert_eq!(kernel_entry_message_line(), b"tosm-os: kernel entry reached\r\n");
+        assert_eq!(
+            kernel_entry_message_line(),
+            b"tosm-os: kernel entry reached\r\n"
+        );
     }
 
     #[test]

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: centralize canonical boot banner line (with CRLF) in kernel for UEFI serial output reuse
-- Status: ready_for_ci (awaiting CI run on canonical banner-line centralization)
+- Subtask: fix CI format failure for canonical boot banner line assertions
+- Status: ready_for_ci (awaiting CI run on rustfmt-only assertion reflow)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -39,6 +39,9 @@ mod tests {
     #[test]
     fn boot_banner_line_bytes_include_crlf() {
         assert_eq!(BOOT_BANNER_LINE, "tosm-os: kernel entry reached\r\n");
-        assert_eq!(boot_banner_line_bytes(), b"tosm-os: kernel entry reached\r\n");
+        assert_eq!(
+            boot_banner_line_bytes(),
+            b"tosm-os: kernel entry reached\r\n"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- The CI `format` job failed due to rustfmt reflow of long `assert_eq!` lines in boot-banner tests, so apply the smallest change to restore formatting compliance and unblock CI before adding new scope.

### Description
- Reflowed the long `assert_eq!` lines in `kernel/src/lib.rs` and `boot/uefi-entry/src/lib.rs` tests to the rustfmt-preferred multiline form and updated `docs/status/current.md` to reflect the CI-format-fix subtask.

### Testing
- No automated tests were run locally; the most recent recorded CI run (`22975354212`) showed `format: failure` while `clippy`, `tests`, `build`, and `smoke` were `success`, and this change targets only the formatting failure so CI should be re-run to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27727164c832f9128cd083b489524)