### PR TITLE
boot: centralize early panic serial line through kernel API

### DIFF
--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -122,6 +122,12 @@ pub const fn kernel_entry_message_line() -> &'static [u8] {
     kernel::boot_banner_line_bytes()
 }
 
+/// Returns the deterministic early-boot panic line expected by firmware panic paths.
+#[must_use]
+pub const fn panic_message_line() -> &'static [u8] {
+    kernel::boot_panic_line_bytes()
+}
+
 /// UEFI ABI entrypoint for the boot milestone.
 ///
 /// Writes the canonical kernel entry banner to COM1 as the first concrete firmware output path.
@@ -141,7 +147,7 @@ use core::panic::PanicInfo;
 fn panic(_info: &PanicInfo<'_>) -> ! {
     let mut serial = SerialCom1::new();
     serial.init();
-    serial.write_all(b"tosm-os: panic in uefi-entry\r\n");
+    serial.write_all(panic_message_line());
     loop {}
 }
 
@@ -151,8 +157,8 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::{
-        kernel_entry_message_line, EfiStatus, BAUD_DIVISOR_38400, LINE_CONTROL_8N1,
-        LINE_CONTROL_DLAB, LINE_STATUS_TRANSMITTER_EMPTY,
+        kernel_entry_message_line, panic_message_line, EfiStatus, BAUD_DIVISOR_38400,
+        LINE_CONTROL_8N1, LINE_CONTROL_DLAB, LINE_STATUS_TRANSMITTER_EMPTY,
     };
 
     #[test]
@@ -161,6 +167,11 @@ mod tests {
             kernel_entry_message_line(),
             b"tosm-os: kernel entry reached\r\n"
         );
+    }
+
+    #[test]
+    fn panic_message_line_matches_kernel_canonical_panic_line() {
+        assert_eq!(panic_message_line(), b"tosm-os: panic in uefi-entry\r\n");
     }
 
     #[test]

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -39,6 +39,8 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 7. ✅ Centralize the CRLF-terminated banner line in `kernel` and consume it from `boot/uefi-entry`.
 8. ✅ Initialize COM1 UART line settings in `boot/uefi-entry` before transmitting banner bytes.
 
+9. ✅ Centralize the early-boot panic serial line in `kernel` and consume it from `boot/uefi-entry` panic handler.
+
 ## Risks
 
 - Missing `x86_64-unknown-uefi` target can block UEFI build/lint/smoke steps later.

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: initialize COM1 UART defaults before boot banner transmit
-- Status: in_progress (UART init slice implemented; awaiting CI run)
+- Subtask: centralize early-boot panic serial line in kernel banner API
+- Status: in_progress (panic-line centralization slice implemented; awaiting CI run)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -7,6 +7,9 @@ pub const BOOT_BANNER: &str = "tosm-os: kernel entry reached";
 /// Canonical serial line emitted from boot entry paths.
 pub const BOOT_BANNER_LINE: &str = "tosm-os: kernel entry reached\r\n";
 
+/// Canonical panic line emitted by early boot firmware entry paths.
+pub const BOOT_PANIC_LINE: &str = "tosm-os: panic in uefi-entry\r\n";
+
 /// Returns the kernel boot banner as a byte slice for firmware serial writers.
 #[must_use]
 pub const fn boot_banner_bytes() -> &'static [u8] {
@@ -19,12 +22,21 @@ pub const fn boot_banner_line_bytes() -> &'static [u8] {
     BOOT_BANNER_LINE.as_bytes()
 }
 
+/// Returns the canonical panic line (including CRLF) for early serial panic paths.
+#[must_use]
+pub const fn boot_panic_line_bytes() -> &'static [u8] {
+    BOOT_PANIC_LINE.as_bytes()
+}
+
 #[cfg(test)]
 extern crate std;
 
 #[cfg(test)]
 mod tests {
-    use super::{boot_banner_bytes, boot_banner_line_bytes, BOOT_BANNER, BOOT_BANNER_LINE};
+    use super::{
+        boot_banner_bytes, boot_banner_line_bytes, boot_panic_line_bytes, BOOT_BANNER,
+        BOOT_BANNER_LINE, BOOT_PANIC_LINE,
+    };
 
     #[test]
     fn boot_banner_matches_expected_literal() {
@@ -43,5 +55,11 @@ mod tests {
             boot_banner_line_bytes(),
             b"tosm-os: kernel entry reached\r\n"
         );
+    }
+
+    #[test]
+    fn boot_panic_line_bytes_include_crlf() {
+        assert_eq!(BOOT_PANIC_LINE, "tosm-os: panic in uefi-entry\r\n");
+        assert_eq!(boot_panic_line_bytes(), b"tosm-os: panic in uefi-entry\r\n");
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce duplicated early-boot serial literals by centralizing the canonical panic line with the already-centralized boot banner.
- Keep early firmware output strings auditable and stable across entry paths to simplify smoke tests and future QEMU automation.

### Description
- Added `BOOT_PANIC_LINE` and `boot_panic_line_bytes()` to `kernel/src/lib.rs` to expose a canonical CRLF-terminated panic line.
- Updated `boot/uefi-entry/src/lib.rs` to call a new `panic_message_line()` wrapper that consumes `kernel::boot_panic_line_bytes()` from the kernel crate instead of embedding a duplicate literal.
- Added unit tests locking the panic-line bytes in both `kernel` (`boot_panic_line_bytes_include_crlf`) and `uefi-entry` (`panic_message_line_matches_kernel_canonical_panic_line`).
- Updated `docs/plan/boot-entry.md` and `docs/status/current.md` to record this slice as complete/in-progress and reflect the new subtask description.

### Testing
- No local automated test runs were performed for this change; verification is delegated to CI per repository contract and expected `make` targets (`make fmt`, `make lint`, `make test`, `make build`, `make smoke`).
- Unit tests were added: `boot_panic_line_bytes_include_crlf` in `kernel` and `panic_message_line_matches_kernel_canonical_panic_line` in `boot/uefi-entry` to lock the canonical panic bytes.
- The previous CI run (prior to this change) reported `conclusion: success` for format/clippy/tests/build/smoke in `docs/status/ci-feedback.json` and related reports; CI will validate these targets for the new changes after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27fb9ae5c832f9ef9ea13c60df90b)