### PR TITLE
boot: add canonical efi_main completion serial line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The repository is progressing through the first milestone (`bootloader and entry
 
 This slice introduces a minimal Rust workspace with:
 
-- a host-testable `kernel` crate that owns an explicit deterministic boot banner literal plus a canonical CRLF-terminated serial line helper
-- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes the kernel-provided banner line to COM1, and includes a minimal panic handler
+- a host-testable `kernel` crate that owns an explicit deterministic boot banner literal plus canonical CRLF-terminated serial line helpers for both entry and completion paths
+- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes kernel-provided banner and completion lines to COM1, and includes a minimal panic handler
 
 Canonical boot banner:
 

--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -128,6 +128,12 @@ pub const fn panic_message_line() -> &'static [u8] {
     kernel::boot_panic_line_bytes()
 }
 
+/// Returns the deterministic completion line expected before firmware returns success.
+#[must_use]
+pub const fn entry_done_message_line() -> &'static [u8] {
+    kernel::boot_entry_done_line_bytes()
+}
+
 /// UEFI ABI entrypoint for the boot milestone.
 ///
 /// Writes the canonical kernel entry banner to COM1 as the first concrete firmware output path.
@@ -136,6 +142,7 @@ pub extern "efiapi" fn efi_main(_image: EfiHandle, _system_table: EfiSystemTable
     let mut serial = SerialCom1::new();
     serial.init();
     serial.write_all(kernel_entry_message_line());
+    serial.write_all(entry_done_message_line());
     EfiStatus::SUCCESS
 }
 
@@ -157,8 +164,8 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::{
-        kernel_entry_message_line, panic_message_line, EfiStatus, BAUD_DIVISOR_38400,
-        LINE_CONTROL_8N1, LINE_CONTROL_DLAB, LINE_STATUS_TRANSMITTER_EMPTY,
+        entry_done_message_line, kernel_entry_message_line, panic_message_line, EfiStatus,
+        BAUD_DIVISOR_38400, LINE_CONTROL_8N1, LINE_CONTROL_DLAB, LINE_STATUS_TRANSMITTER_EMPTY,
     };
 
     #[test]
@@ -172,6 +179,11 @@ mod tests {
     #[test]
     fn panic_message_line_matches_kernel_canonical_panic_line() {
         assert_eq!(panic_message_line(), b"tosm-os: panic in uefi-entry\r\n");
+    }
+
+    #[test]
+    fn entry_done_message_line_matches_kernel_canonical_completion_line() {
+        assert_eq!(entry_done_message_line(), b"tosm-os: efi_main completed\r\n");
     }
 
     #[test]

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -41,6 +41,8 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
 9. ✅ Centralize the early-boot panic serial line in `kernel` and consume it from `boot/uefi-entry` panic handler.
 
+10. ✅ Add a canonical completion serial line in `kernel` and emit it from `boot/uefi-entry` before returning `EFI_SUCCESS`.
+
 ## Risks
 
 - Missing `x86_64-unknown-uefi` target can block UEFI build/lint/smoke steps later.

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: centralize early-boot panic serial line in kernel banner API
-- Status: in_progress (panic-line centralization slice implemented; awaiting CI run)
+- Subtask: add canonical efi_main completion serial line to kernel banner API
+- Status: in_progress (efi_main completion-line slice implemented; awaiting CI run)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -10,6 +10,9 @@ pub const BOOT_BANNER_LINE: &str = "tosm-os: kernel entry reached\r\n";
 /// Canonical panic line emitted by early boot firmware entry paths.
 pub const BOOT_PANIC_LINE: &str = "tosm-os: panic in uefi-entry\r\n";
 
+/// Canonical completion line emitted when firmware entry returns success.
+pub const BOOT_ENTRY_DONE_LINE: &str = "tosm-os: efi_main completed\r\n";
+
 /// Returns the kernel boot banner as a byte slice for firmware serial writers.
 #[must_use]
 pub const fn boot_banner_bytes() -> &'static [u8] {
@@ -28,14 +31,21 @@ pub const fn boot_panic_line_bytes() -> &'static [u8] {
     BOOT_PANIC_LINE.as_bytes()
 }
 
+/// Returns the canonical completion line (including CRLF) for firmware exit paths.
+#[must_use]
+pub const fn boot_entry_done_line_bytes() -> &'static [u8] {
+    BOOT_ENTRY_DONE_LINE.as_bytes()
+}
+
 #[cfg(test)]
 extern crate std;
 
 #[cfg(test)]
 mod tests {
     use super::{
-        boot_banner_bytes, boot_banner_line_bytes, boot_panic_line_bytes, BOOT_BANNER,
-        BOOT_BANNER_LINE, BOOT_PANIC_LINE,
+        boot_banner_bytes, boot_banner_line_bytes, boot_entry_done_line_bytes,
+        boot_panic_line_bytes, BOOT_BANNER, BOOT_BANNER_LINE, BOOT_ENTRY_DONE_LINE,
+        BOOT_PANIC_LINE,
     };
 
     #[test]
@@ -61,5 +71,14 @@ mod tests {
     fn boot_panic_line_bytes_include_crlf() {
         assert_eq!(BOOT_PANIC_LINE, "tosm-os: panic in uefi-entry\r\n");
         assert_eq!(boot_panic_line_bytes(), b"tosm-os: panic in uefi-entry\r\n");
+    }
+
+    #[test]
+    fn boot_entry_done_line_bytes_include_crlf() {
+        assert_eq!(BOOT_ENTRY_DONE_LINE, "tosm-os: efi_main completed\r\n");
+        assert_eq!(
+            boot_entry_done_line_bytes(),
+            b"tosm-os: efi_main completed\r\n"
+        );
     }
 }

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -5,10 +5,16 @@ set -euo pipefail
 # This script intentionally checks for the deterministic boot banner contract
 # until the QEMU boot path is added in a later slice.
 expected_banner='tosm-os: kernel entry reached'
+expected_entry_done='tosm-os: efi_main completed'
 
 if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
   echo "smoke: expected boot banner not found"
   exit 1
 fi
 
-echo "smoke: boot banner contract present"
+if ! grep --fixed-strings --quiet -- "${expected_entry_done}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+  echo "smoke: expected efi_main completion line not found"
+  exit 1
+fi
+
+echo "smoke: boot banner and completion contracts present"


### PR DESCRIPTION
### Motivation
- Continue the small incremental work on the `bootloader and entry` milestone by making firmware output slightly more structured and deterministic. 
- Provide a canonical, kernel-owned completion serial line for firmware paths to emit before returning success so smoke tests and future QEMU wiring have a stable contract.

### Description
- Add `BOOT_ENTRY_DONE_LINE` and `boot_entry_done_line_bytes()` to `kernel/src/lib.rs` and extend kernel unit tests to assert the new string and byte helper. 
- Expose `entry_done_message_line()` in `boot/uefi-entry/src/lib.rs` and emit that completion line immediately before returning `EFI_SUCCESS`, plus add a unit test to validate the wiring. 
- Extend the placeholder smoke script `tools/smoke-test.sh` to verify both the boot banner and the new completion line are present in source, and update `docs/plan/boot-entry.md`, `docs/status/current.md`, and `README.md` to reflect the new subtask. 
- No dependencies added and no broad refactor; changes are a small vertical slice focused on boot output contract.

### Testing
- The latest stored CI prior to this change is `success` (run `22994374834`) with `format`, `clippy`, `tests`, `build`, and `smoke` all reported `success` in `docs/status/` artifacts. 
- This patch adds unit tests in both `kernel` and `boot/uefi-entry` but has not yet been verified by CI on `main`; please run the expected verification sequence `make fmt`, `make lint`, `make test`, `make build`, and `make smoke` in GitHub Actions to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2939f5f38832f900d7625813063ab)