### PR TITLE
Fix rustfmt failure in UEFI completion-line test

### DIFF
--- a/boot/uefi-entry/src/lib.rs
+++ b/boot/uefi-entry/src/lib.rs
@@ -183,7 +183,10 @@ mod tests {
 
     #[test]
     fn entry_done_message_line_matches_kernel_canonical_completion_line() {
-        assert_eq!(entry_done_message_line(), b"tosm-os: efi_main completed\r\n");
+        assert_eq!(
+            entry_done_message_line(),
+            b"tosm-os: efi_main completed\r\n"
+        );
     }
 
     #[test]

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: add canonical efi_main completion serial line to kernel banner API
-- Status: in_progress (efi_main completion-line slice implemented; awaiting CI run)
+- Subtask: fix rustfmt failure for canonical efi_main completion-line test formatting
+- Status: in_progress (formatted completion-line assertion to match rustfmt output; awaiting CI rerun)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria


### PR DESCRIPTION
### Motivation
- The latest CI run (`22997476568`) failed only on the `format` job due to a rustfmt-driven assertion formatting diff in the UEFI entry tests. 
- The smallest corrective action is to match the rustfmt-expected multi-line `assert_eq!` styling for the completion-line test and update status docs accordingly.

### Description
- Reformatted the `entry_done_message_line_matches_kernel_canonical_completion_line` assertion in `boot/uefi-entry/src/lib.rs` to the multi-line style expected by rustfmt. 
- Updated `docs/status/current.md` to note that the subtask is the rustfmt-failure fix and that the change is awaiting a CI rerun. 
- Changes committed with message `Fix rustfmt failure in completion-line test`.

### Testing
- Previous CI (`22997476568`) reported `format: failure` and `clippy/tests/build/smoke: success`, with the `fmt` log showing the exact assertion formatting diff. 
- No local automated test jobs (`make fmt`, `make test`, etc.) were executed in-repo as verification is delegated to GitHub Actions per project contract. 
- Awaiting CI rerun to verify the format job now succeeds; verification will be visible in `docs/status/*` after the CI run completes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b295a46da0832faf2eebaa60b989a5)