### PR TITLE
Strengthen boot smoke contract with panic-line coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Canonical boot banner:
 
 - `tosm-os: kernel entry reached`
 
-A temporary smoke script (`tools/smoke-test.sh`) currently enforces the deterministic boot banner contract while QEMU automation is still pending.
+A temporary smoke script (`tools/smoke-test.sh`) currently enforces deterministic serial message contracts (boot banner, panic line, and completion line) while QEMU automation is still pending.
 
 Workspace validation commands are wired through canonical `make` targets:
 

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -43,6 +43,8 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
 10. ✅ Add a canonical completion serial line in `kernel` and emit it from `boot/uefi-entry` before returning `EFI_SUCCESS`.
 
+11. ✅ Extend the smoke contract check to require the canonical early-boot panic line alongside banner and completion lines.
+
 ## Risks
 
 - Missing `x86_64-unknown-uefi` target can block UEFI build/lint/smoke steps later.

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: fix rustfmt failure for canonical efi_main completion-line test formatting
-- Status: in_progress (formatted completion-line assertion to match rustfmt output; awaiting CI rerun)
+- Subtask: extend smoke contract coverage to include canonical early-boot panic line
+- Status: in_progress (added panic-line presence check to smoke gate; awaiting CI rerun)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # This script intentionally checks for the deterministic boot banner contract
 # until the QEMU boot path is added in a later slice.
 expected_banner='tosm-os: kernel entry reached'
+expected_panic='tosm-os: panic in uefi-entry'
 expected_entry_done='tosm-os: efi_main completed'
 
 if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
@@ -17,4 +18,9 @@ if ! grep --fixed-strings --quiet -- "${expected_entry_done}" kernel/src/lib.rs 
   exit 1
 fi
 
-echo "smoke: boot banner and completion contracts present"
+if ! grep --fixed-strings --quiet -- "${expected_panic}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+  echo "smoke: expected panic line not found"
+  exit 1
+fi
+
+echo "smoke: boot banner, panic, and completion contracts present"


### PR DESCRIPTION
### Motivation

- Continue the active `bootloader and entry` milestone by making a small, incremental hardening change that keeps the repository buildable and reviewable. 
- Ensure the placeholder smoke gate more fully represents the canonical early-boot serial contract by requiring the kernel and UEFI entry to expose the panic line as well as banner and completion lines.

### Description

- Extend `tools/smoke-test.sh` to check for the canonical panic line `tosm-os: panic in uefi-entry` in addition to the boot banner and completion line, and update the success message. 
- Update `docs/status/current.md` to record the new subtask and status note and append the completed step in `docs/plan/boot-entry.md`. 
- Refresh `README.md` to document that the temporary smoke script enforces the banner, panic, and completion contracts.

### Testing

- No automated tests were executed locally for this change; post-merge GitHub Actions are expected to run `make fmt`, `make lint`, `make test`, `make build`, and `make smoke` as the authoritative validation. 
- The repository's latest recorded CI run was `22997737983` with a `success` conclusion for format, clippy, tests, build, and smoke, and the advised next action is to continue the milestone slice.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2974e9554832f81c9f7826b994e02)