### PR TITLE
Strengthen boot smoke contract with canonical CRLF line checks

### DIFF
--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -45,6 +45,8 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
 11. ✅ Extend the smoke contract check to require the canonical early-boot panic line alongside banner and completion lines.
 
+12. ✅ Extend the smoke contract check to require explicit canonical CRLF line literals for banner, panic, and completion messages.
+
 ## Risks
 
 - Missing `x86_64-unknown-uefi` target can block UEFI build/lint/smoke steps later.

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: extend smoke contract coverage to include canonical early-boot panic line
-- Status: in_progress (added panic-line presence check to smoke gate; awaiting CI rerun)
+- Subtask: extend smoke contract coverage to assert canonical CRLF-terminated line literals for banner, panic, and completion
+- Status: in_progress (added CRLF literal checks for banner/panic/completion in smoke gate; awaiting CI rerun)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 expected_banner='tosm-os: kernel entry reached'
 expected_panic='tosm-os: panic in uefi-entry'
 expected_entry_done='tosm-os: efi_main completed'
+expected_banner_line='tosm-os: kernel entry reached\r\n'
+expected_panic_line='tosm-os: panic in uefi-entry\r\n'
+expected_entry_done_line='tosm-os: efi_main completed\r\n'
 
 if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
   echo "smoke: expected boot banner not found"
@@ -23,4 +26,19 @@ if ! grep --fixed-strings --quiet -- "${expected_panic}" kernel/src/lib.rs boot/
   exit 1
 fi
 
-echo "smoke: boot banner, panic, and completion contracts present"
+if ! grep --fixed-strings --quiet -- "${expected_banner_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+  echo "smoke: expected boot banner CRLF contract not found"
+  exit 1
+fi
+
+if ! grep --fixed-strings --quiet -- "${expected_panic_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+  echo "smoke: expected panic CRLF contract not found"
+  exit 1
+fi
+
+if ! grep --fixed-strings --quiet -- "${expected_entry_done_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+  echo "smoke: expected efi_main completion CRLF contract not found"
+  exit 1
+fi
+
+echo "smoke: boot banner, panic, completion, and CRLF contracts present"


### PR DESCRIPTION
### Motivation
- Harden the bootloader/entry smoke gate by ensuring canonical early-boot messages include the expected CRLF terminator so firmware consumers and smoke automation cannot drift on line endings.

### Description
- Add explicit CRLF-terminated literals and presence checks to `tools/smoke-test.sh` for the banner, panic, and completion lines (`expected_*_line` variables and `grep` checks). 
- Preserve the original plain-string presence checks and update the smoke success message to reflect CRLF contract coverage.
- Update `docs/status/current.md` to record the refined subtask and `docs/plan/boot-entry.md` to add the new implementation step documenting this CRLF contract requirement.
- Commit message: `Strengthen boot smoke contract with CRLF literal checks`.

### Testing
- Existing recorded CI is `success` (run id `22998023620`) per `docs/status/latest-ci.md` and `docs/status/reports/*`; this change awaits the next CI run for verification. 
- No automated test suite was executed locally against the modified code; verification is delegated to GitHub Actions after merge via the repository `make` targets (`make fmt`, `make lint`, `make test`, `make build`, `make smoke`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29905522c832fbe9431551847947d)