### PR TITLE
Add UEFI `bootx64` binary target and opportunistic QEMU smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ The repository is progressing through the first milestone (`bootloader and entry
 This slice introduces a minimal Rust workspace with:
 
 - a host-testable `kernel` crate that owns an explicit deterministic boot banner literal plus canonical CRLF-terminated serial line helpers for both entry and completion paths
-- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes kernel-provided banner and completion lines to COM1, and includes a minimal panic handler
+- a `boot/uefi-entry` crate that defines a UEFI ABI `efi_main`, writes kernel-provided banner and completion lines to COM1, includes a minimal panic handler, and provides a `bootx64` UEFI application target
 
 Canonical boot banner:
 
 - `tosm-os: kernel entry reached`
 
-A temporary smoke script (`tools/smoke-test.sh`) currently enforces deterministic serial message contracts (boot banner, panic line, and completion line) while QEMU automation is still pending.
+The smoke script (`tools/smoke-test.sh`) enforces deterministic serial message contracts and, when `qemu-system-x86_64` plus OVMF firmware images are available, boots the generated UEFI image in QEMU and verifies serial output.
 
 Workspace validation commands are wired through canonical `make` targets:
 
@@ -21,7 +21,7 @@ Workspace validation commands are wired through canonical `make` targets:
 - `make build`
 - `make smoke`
 
-Full QEMU smoke automation remains the next incremental step.
+QEMU runtime smoke execution is opportunistic: it runs when the host environment provides QEMU + OVMF and otherwise leaves a contract-only smoke pass.
 
 ## Codex + CI workflow
 

--- a/boot/uefi-entry/Cargo.toml
+++ b/boot/uefi-entry/Cargo.toml
@@ -10,3 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 kernel = { path = "../../kernel" }
+
+[[bin]]
+name = "bootx64"
+path = "src/main.rs"

--- a/boot/uefi-entry/src/main.rs
+++ b/boot/uefi-entry/src/main.rs
@@ -1,0 +1,11 @@
+#![no_std]
+#![no_main]
+#![forbid(unsafe_op_in_unsafe_fn)]
+
+use uefi_entry::{efi_main as uefi_crate_entry, EfiHandle, EfiStatus, EfiSystemTable};
+
+/// UEFI firmware entry symbol for the boot application image.
+#[no_mangle]
+pub extern "efiapi" fn efi_main(handle: EfiHandle, system_table: EfiSystemTable) -> EfiStatus {
+    uefi_crate_entry(handle, system_table)
+}

--- a/docs/plan/boot-entry.md
+++ b/docs/plan/boot-entry.md
@@ -5,7 +5,8 @@ Create the smallest bootable x86_64 Rust OS slice that can start in QEMU and emi
 ## Current state
 
 - Repository now contains a Cargo workspace with a minimal `kernel` crate.
-- The `kernel` crate exports a deterministic boot banner literal and byte-slice helper for future firmware serial output wiring.
+- The `kernel` crate exports deterministic boot serial line literals and byte-slice helpers used by firmware entry paths.
+- The `boot/uefi-entry` crate now includes a UEFI application binary target (`bootx64`) in addition to its host-testable library.
 - Active milestone is `bootloader and entry`.
 
 ## Constraints
@@ -23,8 +24,8 @@ Build the milestone incrementally:
 - start with a tiny no_std `kernel` crate that defines the canonical boot banner
 - add a separate UEFI entry crate that consumes this banner
 - extend that crate to write the banner to COM1
-- only then add QEMU smoke automation tied to the expected serial output
-- centralize the canonical CRLF-terminated banner line in the kernel crate so firmware entry paths cannot drift
+- add smoke automation that first checks source contracts, then runs QEMU when firmware tooling is available
+- centralize canonical CRLF-terminated lines in the kernel crate so firmware entry paths cannot drift
 
 This keeps early milestone slices auditable and minimizes cross-cutting risk.
 
@@ -38,14 +39,11 @@ This keeps early milestone slices auditable and minimizes cross-cutting risk.
 6. ✅ Update README and status docs for each slice.
 7. ✅ Centralize the CRLF-terminated banner line in `kernel` and consume it from `boot/uefi-entry`.
 8. ✅ Initialize COM1 UART line settings in `boot/uefi-entry` before transmitting banner bytes.
-
 9. ✅ Centralize the early-boot panic serial line in `kernel` and consume it from `boot/uefi-entry` panic handler.
-
 10. ✅ Add a canonical completion serial line in `kernel` and emit it from `boot/uefi-entry` before returning `EFI_SUCCESS`.
-
 11. ✅ Extend the smoke contract check to require the canonical early-boot panic line alongside banner and completion lines.
-
 12. ✅ Extend the smoke contract check to require explicit canonical CRLF line literals for banner, panic, and completion messages.
+13. ✅ Add a UEFI `bootx64` application target and extend smoke automation to execute a QEMU boot check when QEMU + OVMF are available.
 
 ## Risks
 

--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -1,8 +1,8 @@
 # Current milestone
 
 - Active milestone: bootloader and entry
-- Subtask: extend smoke contract coverage to assert canonical CRLF-terminated line literals for banner, panic, and completion
-- Status: in_progress (added CRLF literal checks for banner/panic/completion in smoke gate; awaiting CI rerun)
+- Subtask: add a UEFI application target and opportunistic QEMU smoke execution over serial output
+- Status: in_progress (implemented `bootx64` UEFI target and smoke script now runs QEMU when firmware tooling exists)
 - Note: Codex writes code/docs only and waits for GitHub Actions feedback after merge to `main`.
 
 ## Done criteria
@@ -12,6 +12,11 @@
 - [ ] make build
 - [ ] make smoke
 - [x] docs updated
+
+## Progress update
+
+- Completed slice: UEFI binary target (`bootx64`) is now defined for `x86_64-unknown-uefi`, and smoke now does both source-level contract checks and runtime serial validation in QEMU when `qemu-system-x86_64` + OVMF are available.
+- Next slice: make QEMU smoke mandatory in CI by provisioning deterministic OVMF firmware paths and enforcing runtime execution instead of fallback mode.
 
 <!-- ci-status:start -->
 ## Latest CI automation

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Boot milestone placeholder smoke gate.
-# This script intentionally checks for the deterministic boot banner contract
-# until the QEMU boot path is added in a later slice.
 expected_banner='tosm-os: kernel entry reached'
 expected_panic='tosm-os: panic in uefi-entry'
 expected_entry_done='tosm-os: efi_main completed'
@@ -11,34 +8,125 @@ expected_banner_line='tosm-os: kernel entry reached\r\n'
 expected_panic_line='tosm-os: panic in uefi-entry\r\n'
 expected_entry_done_line='tosm-os: efi_main completed\r\n'
 
-if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected boot banner not found"
-  exit 1
-fi
+contract_check() {
+  if ! grep --fixed-strings --quiet -- "${expected_banner}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected boot banner not found"
+    exit 1
+  fi
 
-if ! grep --fixed-strings --quiet -- "${expected_entry_done}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected efi_main completion line not found"
-  exit 1
-fi
+  if ! grep --fixed-strings --quiet -- "${expected_entry_done}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected efi_main completion line not found"
+    exit 1
+  fi
 
-if ! grep --fixed-strings --quiet -- "${expected_panic}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected panic line not found"
-  exit 1
-fi
+  if ! grep --fixed-strings --quiet -- "${expected_panic}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected panic line not found"
+    exit 1
+  fi
 
-if ! grep --fixed-strings --quiet -- "${expected_banner_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected boot banner CRLF contract not found"
-  exit 1
-fi
+  if ! grep --fixed-strings --quiet -- "${expected_banner_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected boot banner CRLF contract not found"
+    exit 1
+  fi
 
-if ! grep --fixed-strings --quiet -- "${expected_panic_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected panic CRLF contract not found"
-  exit 1
-fi
+  if ! grep --fixed-strings --quiet -- "${expected_panic_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected panic CRLF contract not found"
+    exit 1
+  fi
 
-if ! grep --fixed-strings --quiet -- "${expected_entry_done_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
-  echo "smoke: expected efi_main completion CRLF contract not found"
-  exit 1
-fi
+  if ! grep --fixed-strings --quiet -- "${expected_entry_done_line}" kernel/src/lib.rs boot/uefi-entry/src/lib.rs; then
+    echo "smoke: expected efi_main completion CRLF contract not found"
+    exit 1
+  fi
 
-echo "smoke: boot banner, panic, completion, and CRLF contracts present"
+  echo "smoke: serial message contracts present"
+}
+
+find_ovmf_code() {
+  local candidate
+  for candidate in \
+    "${OVMF_CODE_PATH:-}" \
+    /usr/share/OVMF/OVMF_CODE.fd \
+    /usr/share/ovmf/OVMF.fd \
+    /usr/share/edk2/x64/OVMF_CODE.fd; do
+    if [[ -n "${candidate}" && -f "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_ovmf_vars() {
+  local candidate
+  for candidate in \
+    "${OVMF_VARS_PATH:-}" \
+    /usr/share/OVMF/OVMF_VARS.fd \
+    /usr/share/edk2/x64/OVMF_VARS.fd; do
+    if [[ -n "${candidate}" && -f "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_qemu_smoke() {
+  local qemu_bin="${QEMU_BIN:-qemu-system-x86_64}"
+  if ! command -v "${qemu_bin}" >/dev/null 2>&1; then
+    echo "smoke: ${qemu_bin} unavailable, skipping QEMU execution"
+    return 2
+  fi
+
+  local ovmf_code ovmf_vars
+  if ! ovmf_code="$(find_ovmf_code)"; then
+    echo "smoke: OVMF code firmware unavailable, skipping QEMU execution"
+    return 2
+  fi
+  if ! ovmf_vars="$(find_ovmf_vars)"; then
+    echo "smoke: OVMF vars firmware unavailable, skipping QEMU execution"
+    return 2
+  fi
+
+  cargo build --package uefi-entry --bin bootx64 --target x86_64-unknown-uefi
+
+  local efi_path="target/x86_64-unknown-uefi/debug/bootx64.efi"
+  if [[ ! -f "${efi_path}" ]]; then
+    echo "smoke: expected EFI image missing at ${efi_path}"
+    exit 1
+  fi
+
+  local run_dir
+  run_dir="$(mktemp -d)"
+  trap 'rm -rf "${run_dir}"' EXIT
+  mkdir -p "${run_dir}/EFI/BOOT"
+  cp "${efi_path}" "${run_dir}/EFI/BOOT/BOOTX64.EFI"
+
+  local serial_log="${run_dir}/serial.log"
+  timeout 20s "${qemu_bin}" \
+    -nodefaults \
+    -nographic \
+    -serial file:"${serial_log}" \
+    -drive if=pflash,format=raw,readonly=on,file="${ovmf_code}" \
+    -drive if=pflash,format=raw,file="${ovmf_vars}" \
+    -drive format=raw,file=fat:rw:"${run_dir}"
+
+  if ! grep --fixed-strings --quiet -- "${expected_banner}" "${serial_log}"; then
+    echo "smoke: QEMU serial output missing banner"
+    exit 1
+  fi
+
+  if ! grep --fixed-strings --quiet -- "${expected_entry_done}" "${serial_log}"; then
+    echo "smoke: QEMU serial output missing completion line"
+    exit 1
+  fi
+
+  echo "smoke: QEMU boot output includes banner and completion line"
+}
+
+contract_check
+qemu_status=0
+run_qemu_smoke || qemu_status=$?
+if [[ "${qemu_status}" -ne 0 && "${qemu_status}" -ne 2 ]]; then
+  exit "${qemu_status}"
+fi


### PR DESCRIPTION
### Motivation

- Continue the `bootloader and entry` milestone by producing a standalone UEFI application binary so the repo can produce an EFI image for runtime validation.
- Improve the smoke gate from source-only contract checks to a two-stage flow that can opportunistically run QEMU+OVMF to validate actual serial output when tooling is available.
- Record progress in planning/status docs so the next slice (making QEMU smoke mandatory in CI) is explicit.

### Description

- Add a UEFI application target by appending a `[[bin]]` entry to `boot/uefi-entry/Cargo.toml` and adding `boot/uefi-entry/src/main.rs` that forwards the firmware `efi_main` symbol into the existing crate entry logic. 
- Replace the contract-only smoke gate with an extended `tools/smoke-test.sh` that performs source-level CRLF/line literal checks and, when `qemu-system-x86_64` + OVMF firmware are discoverable, builds the `bootx64` EFI image, boots it in QEMU, and verifies serial log contents. 
- Update documentation and planning files: `README.md`, `docs/plan/boot-entry.md`, and `docs/status/current.md` to reflect the added `bootx64` target, opportunistic QEMU execution, and the next planned slice. 
- Make the smoke script executable and commit the changes (commit `1cd6fc4`).

### Testing

- No automated tests were executed locally in this change set per the development contract. 
- The repository’s latest recorded CI run prior to this change reported `success` for format/clippy/tests/build/smoke as recorded in `docs/status/ci-feedback.json`. 
- After merge, CI is expected to run the standard verification commands: `make fmt`, `make lint`, `make test`, `make build`, and `make smoke`, where `make smoke` will exercise QEMU+OVMF on hosts that provide those tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29b480ce0832fa0e18c5c9b1622d7)