### PR TITLE
Increase default QEMU smoke timeout to 150s to avoid CI flakes

### DIFF
--- a/docs/status/current.md
+++ b/docs/status/current.md
@@ -15,6 +15,9 @@
 
 ## Progress update
 
+- Completed slice: fixed CI smoke timeout failure (`thread-state-ready` missing) by increasing the default QEMU smoke timeout from 90s to 150s, preserving deterministic transcript checks while allowing slower OVMF/TCG boots to finish.
+- Next slice: model scheduler wait-channel contention aging under repeated timer wake retries and deterministic priority inversion recovery contracts.
+
 - Completed slice: fixed smoke timeout pressure by moving the new scheduler debt-aging transcript emission earlier in the UEFI boot transcript so CI can validate the new contract before long-tail firmware runtime stalls.
 - Completed slice: modeled scheduler debt aging decay across timer handoffs with deterministic repayment-cap reset contracts and integrated kernel/UEFI/smoke coverage for the new `scheduler debt aging` line.
 - Next slice: model scheduler wait-channel contention aging under repeated timer wake retries and deterministic priority inversion recovery contracts.

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -663,7 +663,7 @@ run_qemu_smoke() {
   # CI runners without hardware acceleration can take noticeably longer to
   # reach the final scheduler/thread transcript lines, so keep a conservative
   # default timeout while still allowing explicit overrides.
-  local qemu_timeout_secs="${QEMU_TIMEOUT_SECS:-90}"
+  local qemu_timeout_secs="${QEMU_TIMEOUT_SECS:-150}"
   local qemu_status=0
   set +e
   timeout "${qemu_timeout_secs}s" "${qemu_bin}" \


### PR DESCRIPTION
### Motivation
- The CI smoke run timed out before late deterministic scheduler transcript lines (e.g. `thread-state-ready`) could be emitted on slower OVMF/TCG environments, causing a spurious smoke failure; increasing the default timeout reduces these flakes while preserving strict transcript checks.

### Description
- Bumped the default QEMU timeout fallback in `tools/smoke-test.sh` from `90` to `150` seconds and added a brief status entry in `docs/status/current.md` describing the fix; explicit `QEMU_TIMEOUT_SECS` overrides remain unchanged.

### Testing
- Ran `make smoke` which performed contract checks (VGA/serial model tests) and skipped QEMU execution locally; it completed without failures.
- Ran `make fmt`, `make lint`, `make test`, and `make build`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55ca7bf84832f994d0973ae75fc58)